### PR TITLE
"left-image" -> "image-left" layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ left: false
 
 ---
 
-#### Image at left `left-image`
+#### Image at left `image-left`
 Usage:
 
 ```
 ---
-layout: left-image
+layout: image-left
 image: '../assets/images/light-vue-landing.svg'
 equal: true
 ---


### PR DESCRIPTION
Typo in README where "left-image" should actually be "image-left".

https://github.com/lightvue/slidev-theme-light-icons/issues/3